### PR TITLE
hotfix: bucket/common.py에 logger import문 추가

### DIFF
--- a/sandol/bucket/common.py
+++ b/sandol/bucket/common.py
@@ -1,6 +1,8 @@
 import boto3
 from botocore.exceptions import NoCredentialsError, PartialCredentialsError
 
+from api_server.settings import logger
+
 BUCKET_NAME = "sandol-bucket"
 FILE_KEY = "test.json"
 


### PR DESCRIPTION
bucket/common.py에 logger import문이 없어 발생하는 것으로 추정되는 5XX 에러를 위해 import 문을 추가합니다.