### PR TITLE
add: kakao-chatbot package to sandol/requirements.txt

### DIFF
--- a/sandol/requirements.txt
+++ b/sandol/requirements.txt
@@ -19,6 +19,7 @@ httpx==0.27.0
 idna==3.7
 Jinja2==3.1.4
 jmespath==1.0.1
+kakao-chatbot==0.1.2
 mangum==0.17.0
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5


### PR DESCRIPTION
sandol 폴더 안에있는 requirements.txt 파일에 kakao-chatbot 패키지가 없어 발생하는 서버 오류를 해결합니다.