### PR TITLE
fix: kakao-chatbot의 is_empty 논리 문제 대응

### DIFF
--- a/sandol/api_server/meal.py
+++ b/sandol/api_server/meal.py
@@ -247,7 +247,7 @@ async def meal_view(payload: Payload = Depends(parse_payload)):
         response.add_component(lunch_carousel)
     if not dinner_carousel.is_empty:
         response.add_component(dinner_carousel)
-    if response.is_empty:
+    if not response.component_list:
         response.add_component(
             SimpleTextComponent("식단 정보가 없습니다.")
         )


### PR DESCRIPTION
`kakao-chatbot.response.KakaoResponse` 클래스의 `is_empty` 논리가 반대로 되어있어 발생하는 문제에 대응합니다.
`is_empty` 메서드 대신, 직접 `component_list` 인스턴스에 접속하여 비어있는지 유무를 판단합니다.