### PR TITLE
docs: OpenAPI 및 카카오 챗봇 연결 정보 추가와 API 문서 확장

### DIFF
--- a/docs/api_server/index.md
+++ b/docs/api_server/index.md
@@ -1,0 +1,213 @@
+# 산돌이 챗봇 프로젝트 API 문서
+
+## 개요
+
+이 문서는 산돌이 챗봇 프로젝트에서 제공하는 API 엔드포인트 개발 방법을 설명합니다. 이 문서는 FastAPI의 OpenAPI 통합 및 **kakao-chatbot** 라이브러리 사용 방법에 대한 가이드를 제공합니다.
+
+---
+
+## FastAPI 통합 및 OpenAPI 문서화
+
+### `create_openapi_extra` 사용하기
+
+FastAPI는 OpenAPI(Swagger) 문서를 생성하기 위해 엔드포인트에 추가 메타데이터를 제공할 수 있습니다. `create_openapi_extra` 함수는 다음과 같은 요청 페이로드 스키마를 생성합니다:
+
+- **`detail_params`**: 사용자 입력 세부 정보를 설명하는 매개변수.
+- **`client_extra`**: 클라이언트별 정보.
+- **`contexts`**: 사용자 세션에 대한 컨텍스트 정보.
+- **`utterance`**: 예시 사용자 입력.
+
+#### `create_openapi_extra` 예제
+
+다음은 `create_openapi_extra` 함수 사용 템플릿입니다:
+
+```python
+from utils import create_openapi_extra
+
+@meal_api.post(
+    "/example",
+    openapi_extra=create_openapi_extra(
+        detail_params={
+            "example_param": {
+                "origin": "example_value",
+                "value": "example_value",
+            },
+        },
+        client_extra={
+            "client_key": "example_key",
+        },
+        utterance="예시 발화",
+    ),
+)
+async def example_endpoint(payload: Payload = Depends(parse_payload)):
+    """
+    `create_openapi_extra`를 사용하는 예제 엔드포인트입니다.
+
+    ## 카카오 챗봇 연결 정보
+    ---
+    - 동작방식: 발화
+
+    - OpenBuilder:
+        - 블럭: "예제 블럭"
+        - 스킬: "예제 스킬"
+
+    - Params:
+        - detail_params:
+            - example_param(sys.constant): 예제 매개변수.
+        - client_extra:
+            - client_key: 클라이언트별 키.
+    ---
+
+    Return:
+        JSON 응답.
+    """
+    # 엔드포인트 로직
+    return JSONResponse({"message": "예제 응답"})
+```
+
+### Docstring 가이드라인
+
+FastAPI는 docstring을 사용하여 OpenAPI 문서를 생성합니다. docstring에는 다음 내용이 포함되어야 합니다:
+
+1. **목적**: 엔드포인트의 기능을 간략히 설명합니다.
+2. **카카오 챗봇 연결 정보**:
+   - **동작방식**: 발화 또는 버튼 연결로 구분됩니다.
+   - **OpenBuilder**: 해당 엔드포인트와 연결된 블럭 및 스킬의 이름을 명시합니다.
+   - **Params**:
+     - `detail_params`: 카카오톡 챗봇 관리자 센터의 파라미터 설정 정보를 작성합니다.
+     - `client_extra`: 블럭 연결 시 제공되는 추가 정보를 작성합니다.
+3. **반환값**: 응답 내용을 설명합니다.
+
+#### Docstring 예제
+
+```python
+"""
+업체 등록을 승인하는 API 입니다.
+
+## 카카오 챗봇 연결 정보
+---
+- 동작방식: 버튼 연결
+
+- OpenBuilder:
+    - 블럭: "업체 등록 승인"
+    - 스킬: "업체 등록 승인"
+
+- Params:
+    - detail_params:
+        - place(sys.constant): 교내 또는 교외
+    - client_extra:
+        - identification: 식당 ID
+---
+
+Return:
+    JSON 응답.
+"""
+```
+
+#### utils.py와 같은 일반 함수
+- 일반 함수에도 docstring을 작성하여 다른 개발자가 함수의 사용법을 이해할 수 있도록 합니다. 단, 카카오 챗봇 연결 정보는 작성하지 않으며, Google 스타일의 docstring을 사용합니다.
+
+- **Google 스타일의 docstring**은 다음과 같은 형식을 따릅니다:
+
+```python
+def example_function(param1: int, param2: str) -> bool:
+    """
+    함수의 기능을 간략히 설명합니다.
+
+    Args:
+        param1: 매개변수1에 대한 설명.
+        param2: 매개변수2에 대한 설명.
+
+    Returns:
+        함수의 반환값에 대한 설명.
+    """
+```
+
+---
+
+## Kakao-Chatbot 라이브러리 통합
+
+`meal.py` 및 `utils.py` 파일에서는 **kakao-chatbot** 라이브러리를 광범위하게 사용합니다. 이 라이브러리는 Kakao OpenBuilder와의 상호작용을 용이하게 합니다.
+
+### 공식 문서
+
+`kakao-chatbot`라이브러리의 자세한 사용법은 [Kakao Chatbot Documentation](https://kakao-chatbot.readthedocs.io/)을 참조하세요.
+
+카카오 챗봇이 반환할 수 있는 다양한 응답 형식을 지원합니다. 이러한 응답 형식은 위 공식문서와 [카카오톡 챗봇 API 가이드](https://kakaobusiness.gitbook.io/main/tool/chatbot/skill_guide/answer_json_format)를 참조하여 구현할 수 있습니다.
+
+### 주요 구성 요소
+
+1. **Payload 파싱**: 사용자 입력 세부 정보를 추출합니다.
+    여기서 `parse_payload` 함수는 FastAPI의 `Depends`를 사용하여 Kakao Chatbot Payload를 파싱할 수 있도록 `api_server.utils` 모듈에 구현되어 있는 함수입니다.
+
+   ```python
+   from kakao_chatbot import Payload
+   payload: Payload = Depends(parse_payload)
+   ```
+
+2. **응답 생성**: Kakao Chatbot 응답을 생성합니다.
+
+   ```python
+   from kakao_chatbot.response import KakaoResponse, SimpleTextComponent
+
+   response = KakaoResponse()
+   response.add_component(SimpleTextComponent("안녕하세요, Kakao!"))
+   return JSONResponse(response.get_dict())
+   ```
+
+3. **ItemCard와 Carousel**: 복잡한 응답 형식을 구성합니다.
+
+   ```python
+   from kakao_chatbot.response.components import ItemCardComponent, CarouselComponent
+
+   item_card = ItemCardComponent([])
+   item_card.add_item(title="점심", description="맛있는 식사")
+
+   carousel = CarouselComponent()
+   carousel.add_item(item_card)
+   ```
+
+#### 예제: 식단 정보 관리
+
+```python
+@meal_api.post(
+    "/register/restaurant",
+    openapi_extra=create_openapi_extra(
+        detail_params={
+            "name": {"origin": "식당 이름", "value": "예제 식당"},
+        },
+    ),
+)
+async def register_restaurant(payload: Payload = Depends(parse_payload)):
+    """
+    새로운 식당을 등록합니다.
+
+    ## 카카오 챗봇 연결 정보
+    ---
+    - 동작방식: 발화
+
+    - OpenBuilder:
+        - 블럭: "식당 등록"
+        - 스킬: "식당 등록"
+
+    - Params:
+        - detail_params:
+            - name(sys.constant): 식당 이름
+    ---
+
+    Return:
+        등록 결과를 포함한 JSON 응답.
+    """
+    response = KakaoResponse()
+    response.add_component(SimpleTextComponent("식당이 성공적으로 등록되었습니다."))
+    return JSONResponse(response.get_dict())
+```
+
+---
+
+## 개발자 노트
+
+1. **임시 데이터**: `create_openapi_extra`에 설정된 값들은 플레이스홀더이며, 실제 데이터로 교체해야 합니다.
+2. **에러 처리**: `meal_error_response_maker`를 사용하여 에러 응답을 생성하세요.
+3. **테스트**: Swagger UI(`/docs`) 또는 Kakao OpenBuilder를 사용하여 엔드포인트를 검증하세요.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,139 @@
+# 산돌이 프로젝트 개발 문서
+
+## 개요
+산돌이는 **FastAPI** 기반으로 개발된 학국공학대학교 관련 정보 제공 챗봇 서비스입니다. 사용자는 카카오톡 채널을 통해 학국공학대학교 정보를 확인하고 식당 등록, 메뉴 관리 등의 서비스를 이용할 수 있습니다. 이 문서는 새로운 개발자가 프로젝트를 이해하고 기여할 수 있도록 프로젝트 구조, 주요 기능, 환경 설정, 및 실행 방법 등을 상세히 설명합니다.
+
+---
+
+## 프로젝트 구조
+프로젝트는 다음과 같은 디렉터리와 파일로 구성되어 있습니다:
+
+```
+tuk_sandol_team/
+│
+├── sandol/
+│   ├── api_server/
+│   │   ├── __init__.py
+│   │   ├── meal.py           # 학식 관련 API 구현
+│   │   ├── settings.py       # 환경 설정 및 로깅
+│   │   ├── utils.py          # 유틸리티 함수
+│   │   └── tests/
+│   │       ├── __init__.py
+│   │       └── test_app.py   # API 테스트
+│   │
+│   ├── crawler/
+│   │   ├── __init__.py
+│   │   ├── cafeteria.py      # 식당 데이터 관리
+│   │   ├── ibookcrawler.py   # 학식 데이터 처리
+│   │   └── data/             # 학식 데이터 저장
+│   │
+│   ├── tests/                # 전체 테스트
+│   ├── app.py                # FastAPI 애플리케이션 메인 파일
+│   ├── Dockerfile            # 도커 설정 파일
+│   ├── docker-compose.yml    # 도커 컴포즈 설정
+│   ├── requirements.txt      # 의존성 관리
+│   └── __init__.py
+│
+└── tmp/                      # 임시 파일
+```
+
+---
+
+## 주요 파일 및 기능
+
+### 1. `app.py`
+- **설명**: FastAPI 애플리케이션의 진입점입니다.
+- **주요 기능**:
+  - 루트 엔드포인트 (`GET /`) - 간단한 상태 확인
+  - 사용자 ID 반환 엔드포인트 (`POST /get_id`)
+
+### 2. `meal.py`
+- **설명**: 학식 관련 API를 구현합니다.
+- **주요 엔드포인트**:
+  - `/meal/register/restaurant`: 식당 등록
+  - `/meal/register/delete/{meal_type}`: 메뉴 삭제
+  - `/meal/view`: 학식 정보 조회
+  - `/meal/submit`: 식단 확정
+
+### 3. `cafeteria.py`
+- **설명**: 식당 객체를 관리하는 클래스와 관련 메서드를 정의합니다.
+- **주요 클래스**:
+  - `Restaurant`: 식당 데이터 관리 (등록, 수정, 삭제)
+  - `get_meals()`: JSON 파일로부터 식당 정보를 로드하여 객체로 반환
+
+### 4. `ibookcrawler.py`
+- **설명**: 학식 데이터를 가공하는 모듈입니다.
+- **주요 클래스**:
+  - `BookTranslator`: 학식 데이터를 `data.xlsx` 파일에서 추출하여 가공 후 저장
+
+---
+
+## 환경 설정
+
+### 1. `requirements.txt`
+필요한 Python 패키지 목록:
+- FastAPI
+- uvicorn
+- pandas
+- kakao-chatbot 등
+
+### 2. `docker-compose.yml`
+- 서비스 이름: `sandol`
+- 데이터 디렉터리 `/tmp/sandol/data`를 컨테이너의 `/app/crawler/data`에 마운트
+
+---
+
+## 실행 방법
+
+### 1. 로컬 환경에서 실행
+- python 3.11 버전을 사용합니다.
+로컬 환경은 개발 IDE의 linting 등의 기능을 위한 목적으로 사용합니다.
+서버의 실행은 Docker 컨테이너를 통해 진행합니다.
+```bash
+# 의존성 설치
+pip install -r requirements.txt
+
+# 애플리케이션 실행
+python app.py
+```
+
+### 2. 도커를 이용한 실행
+- Docker 컨테이너를 이용하여 애플리케이션을 실행합니다.
+도커 컴포즈를 이용하여 실행합니다.
+volume을 이용하여 데이터를 저장하고 관리하며, 
+`/tmp/sandol/data` 디렉터리와 컨테이너의 `/app/crawler/data` 디렉터리를 연결하여
+동기화 하기 때문에, test 환경에서는 해당 연결 경로를 직접 수정하거나,
+`/tmp/sandol/data` 디렉터리를 직접 생성하여 사용해야 합니다.
+```bash
+# Docker 컨테이너 빌드 및 실행
+docker-compose up --build
+```
+
+### 3. API 테스트
+- API 테스트는 `tests/` 디렉터리에 작성된 코드로 실행 가능합니다. 현재까지는 작성되지 않았습니다.
+```bash
+pytest
+```
+대신, Swagger UI를 이용하여 API를 테스트할 수 있습니다.
+- `http://localhost:8000/docs`로 접속하여 API를 테스트합니다.
+이때, localhost 대신 사용하는 서버의 IP 주소를 입력해야 합니다.
+---
+
+## 추가 참고 사항
+
+### 데이터 저장 구조
+- 학식 데이터는 JSON 파일(`data/test.json`)로 저장됩니다.
+- 학식 데이터는 `Restaurant` 클래스와 `BookTranslator` 클래스에서 관리됩니다.
+
+### 로그 관리
+- 모든 주요 이벤트는 `api_server/settings.py`에 정의된 로깅 설정을 통해 기록됩니다.
+
+### 에러 처리
+- FastAPI 전역 예외 처리기가 구현되어 있어 모든 예외 상황을 JSON 형태로 반환합니다.
+
+---
+
+## 기여 가이드
+1. 새로운 기능을 추가하거나 수정할 경우 테스트 코드를 작성해주세요.
+2. 모든 PR(Pull Request)은 코드 리뷰를 거쳐야 합니다.
+3. 코드 스타일은 [Google Python Style](https://yosseulsin-job.github.io/Google-Python-Style-Guide-kor/)을 준수해주세요. [영어 원문](https://google.github.io/styleguide/pyguide.html)

--- a/sandol/api_server/utils.py
+++ b/sandol/api_server/utils.py
@@ -5,7 +5,7 @@
 
 import os
 import re
-from typing import Literal
+from typing import Literal, Optional
 from functools import wraps
 import traceback
 from datetime import datetime, timedelta
@@ -342,3 +342,214 @@ async def parse_payload(request: Request) -> Payload:
     """
     data_dict = await request.json()
     return Payload.from_dict(data_dict)
+
+def create_openapi_extra(
+        detail_params: Optional[dict] = None,
+        client_extra: Optional[dict] = None,
+        contexts: Optional[list] = None,
+        utterance: Optional[str] = None,
+    ) -> dict:
+    """
+    detail_params, client_extra, contexts를 받아
+    OpenAPI 스키마에 맞게 변환하며, 각각을 default로 설정한다.
+    예시:
+    >>> detail_params = {
+    ...     "Cafeteria": {
+    ...         "origin": "산돌",
+    ...         "value": "산돌식당"
+    ...     }
+    ... }
+    """
+    if detail_params is None:
+        detail_params = {}
+    if client_extra is None:
+        client_extra = {}
+    if contexts is None:
+        contexts = []
+    if utterance is None:
+        utterance = ""
+
+    detail_params_schema = {
+        "type": "object",
+        "additionalProperties": {
+            "type": "object",
+            "properties": {
+                "origin": {"type": "string"},
+                "value": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "object"},
+                    ]
+                },
+                "group_name": {"type": "string"},
+            },
+        },
+        # detail_params를 그대로 default로 설정
+        "default": detail_params,
+    }
+    default_params = {}
+    if detail_params:
+        default_params = {
+            key : value["value"] for key, value in detail_params.items()
+        }
+
+
+    client_extra_schema = {
+        "type": "object",
+        "additionalProperties": {
+            "type": "string"
+        },
+        # client_extra를 그대로 default로 설정
+        "default": client_extra,
+    }
+
+    contexts_schema = {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "lifespan": {"type": "integer"},
+                "ttl": {"type": ["integer", "null"]},
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "value": {"type": "string"},
+                                    "resolved_value": {"type": "string"},
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        # contexts를 그대로 default로 설정
+        "default": contexts,
+    }
+
+    return {
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "intent": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"},
+                                    "name": {"type": "string"},
+                                    "extra": {
+                                        "type": "object",
+                                        "properties": {
+                                            "reason": {"type": "object"},
+                                            "matched_knowledges": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "answer": {"type": "string"},
+                                                        "question": {"type": "string"},
+                                                        "categories": {
+                                                            "type": "array",
+                                                            "items": {"type": "string"},
+                                                        },
+                                                        "landing_url": {"type": "string"},
+                                                        "image_url": {"type": "string"},
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                                "required": ["id", "name"],
+                            },
+                            "user_request": {
+                                "type": "object",
+                                "properties": {
+                                    "timezone": {"type": "string", "default": "Asia/Seoul"},
+                                    "block": {
+                                        "type": "object",
+                                        "additionalProperties": True,
+                                    },
+                                    "utterance": {"type": "string", "default": utterance},
+                                    "lang": {"type": "string", "default": "ko"},
+                                    "user": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {"type": "string", "default": "test_user_id"},
+                                            "type": {"type": "string", "default": "botUserKey"},
+                                            "properties": {
+                                                "type": "object",
+                                                "additionalProperties": True,
+                                            },
+                                        },
+                                        "required": ["id", "type"],
+                                    },
+                                    "params": {
+                                        "type": ["object", "null"],
+                                        "additionalProperties": True,
+                                    },
+                                    "callback_url": {"type": ["string", "null"]},
+                                },
+                                "required": ["timezone", "block", "utterance", "lang", "user"],
+                            },
+                            "bot": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string", "default": "test_bot_id"},
+                                    "name": {"type": "string", "default": "test_bot_name"},
+                                },
+                                "required": ["id", "name"],
+                            },
+                            "action": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"},
+                                    "name": {"type": "string"},
+                                    "params": {
+                                        "type": "object",
+                                        "additionalProperties": {"type": "string"},
+                                        "default": default_params,
+                                    },
+                                    "detailParams": detail_params_schema,
+                                    "clientExtra": client_extra_schema,
+                                },
+                                "required": ["id", "name", "params"],
+                            },
+                            "contexts": contexts_schema,
+                            "params": {
+                                "type": "object",
+                                "additionalProperties": {"type": "string"},
+                            },
+                            "timezone": {"type": "string"},
+                            "user": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"},
+                                    "type": {"type": "string"},
+                                    "properties": {
+                                        "type": "object",
+                                        "additionalProperties": True,
+                                    },
+                                },
+                                "required": ["id", "type"],
+                            },
+                            "utterance": {"type": "string"},
+                            "value": {
+                                "type": "object",
+                                "additionalProperties": {"type": "string"},
+                            },
+                        },
+                        "required": ["intent", "user_request", "bot", "action"],
+                    }
+                }
+            },
+        }
+    }


### PR DESCRIPTION
### 요약
- OpenAPI(Swagger)를 효과적으로 활용할 수 있도록 기능을 추가하고 문서를 확장했습니다.
- 기존 `meal.py`와 `utils.py` 파일에 OpenAPI 및 카카오 챗봇 관련 기능을 통합했습니다.

### 주요 변경 사항
1. **OpenAPI(Swagger) 활용 강화**
   - `create_openapi_extra` 함수 추가로 각 엔드포인트의 요청/응답 스키마를 명확히 정의.
   - Swagger UI를 통해 더욱 직관적으로 API 테스트 및 문서화를 지원.

2. **카카오 챗봇 연결 정보 통합**
   - 모든 엔드포인트에 카카오 챗봇의 동작 방식, OpenBuilder 정보, Params를 포함한 docstring 추가.
   - 챗봇 발화와 버튼 연결 방식에 대한 명세를 포함해 사용자가 카카오 챗봇 연동 작업을 쉽게 이해할 수 있도록 개선.

3. **개발 가이드 문서 생성**
   - 프로젝트 개발 가이드 내용 기술.
   - FastAPI와 Kakao-Chatbot 라이브러리 통합 가이드를 문서화.
   - Swagger와 Kakao OpenBuilder를 활용한 테스트 방법을 상세히 기술.

### 기대 효과
- OpenAPI(Swagger)를 활용한 API 명세와 테스트가 더욱 간편해졌습니다.
- 카카오 챗봇과의 연동 작업을 체계적으로 관리하고 확장할 수 있는 기반을 마련했습니다.

### 참고
- 기존 `meal.py`와 `utils.py` 파일에 새로운 기능과 문서화를 추가한 내용이 포함됩니다.
- 이 PR에서 정의한 OpenAPI 스키마와 카카오 챗봇 연결 정보는 이후 기능 확장 및 유지 보수에 큰 도움을 줄 것입니다.
