### PR TITLE
feat(nginx): 모든 요청을 `/api` 하위로 이동 및 크롤링 방지를 위한 캐싱 적용

### DIFF
--- a/sandol/app.py
+++ b/sandol/app.py
@@ -15,7 +15,7 @@ from api_server.statics import statics_router
 from api_server.utils import error_message, parse_payload
 
 
-app = FastAPI()
+app = FastAPI(root_path="/api")
 app.include_router(meal_api)
 app.include_router(statics_router)
 

--- a/sandol/docker-compose.yml
+++ b/sandol/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     container_name: sandol_container
     ports:
-      - "80:80"
+      - "8080:80"
     volumes:
       - /tmp/sandol/data:/app/crawler/data
 
@@ -15,6 +15,6 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
-      - "8080:80"
+      - "80:80"
     depends_on:
       - sandol

--- a/sandol/docker-compose.yml
+++ b/sandol/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nginx:alpine
     container_name: sandol_nginx
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
       - "80:80"
     depends_on:

--- a/sandol/docker-compose.yml
+++ b/sandol/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: nginx:alpine
     container_name: sandol_nginx
     volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
       - "80:80"
     depends_on:

--- a/sandol/docker-compose.yml
+++ b/sandol/docker-compose.yml
@@ -1,12 +1,20 @@
-version: '3.8'
-
 services:
   sandol:
-      build:
-        context: ./  # Dockerfile이 위치한 디렉터리
-        dockerfile: Dockerfile  # Dockerfile 이름 (기본값: Dockerfile)
-      container_name: sandol_container
-      ports:
-        - "80:80"
-      volumes:
-        - /tmp/sandol/data:/app/crawler/data
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    container_name: sandol_container
+    ports:
+      - "80:80"
+    volumes:
+      - /tmp/sandol/data:/app/crawler/data
+
+  nginx:
+    image: nginx:alpine
+    container_name: sandol_nginx
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8080:80"
+    depends_on:
+      - sandol

--- a/sandol/nginx/nginx.conf
+++ b/sandol/nginx/nginx.conf
@@ -1,18 +1,18 @@
-upstream backend {
-    server sandol:80;
-}
+http {
+    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m max_size=100m inactive=60m use_temp_path=off;
 
-server {
+    server {
     listen 80;
     server_name sandol.sio2.kr;
 
     # 캐시 설정
-    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m max_size=100m inactive=60m use_temp_path=off;
 
     location /api {
-        proxy_pass http://sandol:80;
+        proxy_pass http://sandol:8080;
         proxy_cache my_cache;
         proxy_cache_valid 200 10m;  # 200 OK 응답을 10분간 캐싱
         proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
     }
 }
+}
+

--- a/sandol/nginx/nginx.conf
+++ b/sandol/nginx/nginx.conf
@@ -2,17 +2,14 @@ http {
     proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m max_size=100m inactive=60m use_temp_path=off;
 
     server {
-    listen 80;
-    server_name sandol.sio2.kr;
+        listen 80;
+        server_name sandol.sio2.kr;
 
-    # 캐시 설정
-
-    location /api {
-        proxy_pass http://sandol:8080;
-        proxy_cache my_cache;
-        proxy_cache_valid 200 10m;  # 200 OK 응답을 10분간 캐싱
-        proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        location /api {
+            proxy_pass http://sandol:8080;
+            proxy_cache my_cache;
+            proxy_cache_valid 200 10m;
+            proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        }
     }
 }
-}
-

--- a/sandol/nginx/nginx.conf
+++ b/sandol/nginx/nginx.conf
@@ -1,0 +1,18 @@
+upstream backend {
+    server sandol:80;
+}
+
+server {
+    listen 80;
+    server_name sandol.sio2.kr;
+
+    # 캐시 설정
+    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m max_size=100m inactive=60m use_temp_path=off;
+
+    location /api {
+        proxy_pass http://sandol:80;
+        proxy_cache my_cache;
+        proxy_cache_valid 200 10m;  # 200 OK 응답을 10분간 캐싱
+        proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+    }
+}

--- a/sandol/nginx/nginx.conf
+++ b/sandol/nginx/nginx.conf
@@ -6,7 +6,7 @@ http {
         server_name sandol.sio2.kr;
 
         location /api {
-            proxy_pass http://sandol:8080;
+            proxy_pass http://sandol:80;
             proxy_cache my_cache;
             proxy_cache_valid 200 10m;
             proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;


### PR DESCRIPTION
## 📍 변경 사항  
1. **모든 요청을 `/api` 하위로 이동**  
   - FastAPI의 `root_path`를 `/api`로 변경하여 **모든 엔드포인트가 `/api` 하위에서 동작**하도록 수정  
   - 기존 `/` → `/api/`, `/get_id` → `/api/get_id`, `/docs` → `/api/docs`로 변경됨  
   - **이전 API를 사용 중이라면 반드시 `/api/`를 추가해야 정상적으로 동작**  

2. **봇 크롤링 및 서버 부하 방지**  
   - `/api` 응답에 대해 **Nginx 캐싱 적용 (10분)**  
   - 동일한 요청이 반복적으로 들어올 경우, FastAPI가 아닌 Nginx에서 캐싱된 응답을 반환하여 서버 부담 감소  
   - HTTP 500~504 오류 발생 시 기존 캐시된 응답 유지  

---

# ⚠ **중요한 변경 사항 (필독)**  
✅ **API 요청 경로 변경**  
- 모든 엔드포인트가 `/api` 하위로 이동됨  
- 기존 `/get_id` → **`/api/get_id`**, `/docs` → **`/api/docs`**  
- API를 사용하는 클라이언트는 **요청 경로를 반드시 업데이트해야 함**  

✅ **서버 부하 감소**  
- 크롤러 및 스크래퍼의 무분별한 요청을 차단하여 **API 요청 부담을 줄임**  
- 캐싱된 데이터를 반환하여 **응답 속도를 향상**시키고 서버 리소스 절약  

---

## 🚀 기대 효과  
- 📢 **클라이언트 API 사용 방식 변경 필요** (`/api/` 추가 필수)  
- 📉 **불필요한 API 요청 감소** (Nginx 캐싱 활용)  
- ⚡ **응답 속도 향상** (FastAPI 연산 부담 감소)  

이번 PR을 통해 **API 요청 구조를 일관되게 정리하고, 크롤링을 방어하면서도 서버 부하를 최소화**할 수 있도록 개선하였습니다. 🚀