### PR TITLE
hotfix: sandol_kakao_bot_service 식단 등록 파싱 및 compose 태그 정렬

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,9 @@
+# First-party services build and tag images with ${TAG:-latest}
+# so docker-compose.yml can run the same image names afterward.
 services:
   gateway:
     container_name: sandol-gateway
+    image: sandol-gateway:${TAG:-latest}
     build: ./sandol-gateway/gateway
     ports:
       - "8010:80"
@@ -33,6 +36,7 @@ services:
 
   meal-service:
     container_name: sandol_meal_service
+    image: sandol-sandol_meal_service:${TAG:-latest}
     build: ./sandol_meal_service
     env_file:
       - ./sandol_meal_service/.env
@@ -65,6 +69,7 @@ services:
 
   meal-web:
     container_name: sandol_meal_web
+    image: sandol-sandol_meal_web:${TAG:-latest}
     build: ./sandol_meal_web
     env_file:
       - path: ./sandol_meal_web/.env
@@ -115,6 +120,7 @@ services:
 
   kakao-bot-service:
     container_name: sandol_kakao_bot_service
+    image: sandol-sandol_kakao_bot_service:${TAG:-latest}
     build: ./sandol_kakao_bot_service
     environment:
       SECRET_KEY: ${SECRET_KEY}
@@ -139,6 +145,7 @@ services:
 
   static-info-service:
     container_name: sandol_static_info_service
+    image: sandol-sandol-static-info-service:${TAG:-latest}
     build: ./sandol-static-info-service
     environment:
       SECRET_KEY: ${SECRET_KEY}
@@ -163,6 +170,7 @@ services:
 
   classroom-timetable-service:
     container_name: sandol_classroom_timetable_service
+    image: sandol-sandol_classroom_timetable_service:${TAG:-latest}
     build: ./sandol_classroom_timetable_service
     volumes:
       - ./sandol_classroom_timetable_service/data/lecture_array.json:/app/data/lecture_array.json:ro
@@ -184,6 +192,7 @@ services:
 
   notice-notification:
     container_name: sandol-notice-notification
+    image: sandol-sandol_notice_notification:${TAG:-latest}
     build:
       context: ./sandol_notice_notification
       dockerfile: Dockerfile
@@ -405,6 +414,7 @@ services:
   # --- Auth Relay 서비스 ---
   auth-relay:
     container_name: auth-relay
+    image: sandol-auth-relay:${TAG:-latest}
     build: ./sandol-auth-relay
     env_file:
       - ./sandol-auth-relay/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# First-party services run prebuilt images tagged with ${TAG:-latest}.
 services:
   gateway:
     container_name: sandol-gateway


### PR DESCRIPTION
## 변경 사항
- sandol_kakao_bot_service 식단 등록 whitespace 파싱 hotfix 반영
- reference 디렉터리 ignore 반영된 submodule 포인터 갱신
- docker-compose.dev.yml 빌드 이미지와 docker-compose.yml 실행 이미지 TAG 규칙 정렬

## 검증
- uv run pytest tests/utils/test_meal_split_string.py tests/routers/test_meal_view_ordering.py
- docker compose -f docker-compose.dev.yml config
- docker compose -f docker-compose.yml config
- TAG=dev-tag-test docker compose -f docker-compose.dev.yml build 후 TAG=dev-tag-test docker compose -f docker-compose.yml up -d 시 동일 태그 이미지 참조 확인 (실행 실패 원인은 운영용 bind mount 경로)